### PR TITLE
Add file where we list requirements

### DIFF
--- a/admin/iefieldkit-requirements.md
+++ b/admin/iefieldkit-requirements.md
@@ -6,4 +6,4 @@ This file lists the requirements that all commands in `iefieldkit` should be dev
 * At least version 13.0
 
 # Code dependencies
-* No `iefieldkit` command should be developed in a way that it does not need any other command to be installed. Other commands in the `iefieldkit` are excluded from this rule and an `iefieldkit` may depend on another `iefieldkit` command.
+* No `iefieldkit` command should be developed in a way that it requires other commands to be installed. The only exception is other commands in the `iefieldkit`, i.e. an `iefieldkit` command may depend on another `iefieldkit` command.


### PR DESCRIPTION
I added this file where we can list what requirements we should follow when developing these commands.

I think the main thing to discuss is which minimum Stata version we should target. @bbdaniels and I have run in to some version descreptancies over the last week and he said this in relation to that:

> I would say either Stata 13 or 14 would be best to have as the minimum: Stata 13 since it supports long strings and a host of updates; or Stata 14 for Unicode (which resolves this issue), which we should expect to be used in development settings in a variety of cases and which I think we should be able to support. 

> If you can believe it, Stata 16 is already due next summer (so that will be 4-6 years backward compatibility at release time). 

> To which I would also add we may need to make a checklist to be aware of forwards compatibility as well: graphing commands that use outlines now need additional syntax when version >= 15!

I agree that Stata 13 is a minimum due to the long strings. I need them when parsing long things in the `ietestform` command. The question is if UTF is worth going up to 14. We should probably discuss that a bit before deciding.

What do you think @luizaandrade ?

Once we added to this file and we agree we can just merge this branch.