### PR TITLE
Ietestform aurelie feedback

### DIFF
--- a/src/ado_files/ietestform.ado
+++ b/src/ado_files/ietestform.ado
@@ -272,7 +272,7 @@ qui {
 
 		local error_msg "There are duplicates in the following list names in varaible `listnamevar's:"
 
-		noi report_file add , report_tempfile("`report_tempfile'") testname("NON NUMERIC LIST NAME VALUES") message("`error_msg'") wikifragment("Duplicated_List_Code") table("list row `listnamevar' `valuevar' if list_item_dup != 0")
+		noi report_file add , report_tempfile("`report_tempfile'") testname("DUPLICATED LIST CODES") message("`error_msg'") wikifragment("Duplicated_List_Code") table("list row `listnamevar' `valuevar' if list_item_dup != 0")
 	}
 
 	/***********************************************


### PR DESCRIPTION
Add fixes related to name including non standard spaces. ASCII code 160. Trim does not treat those spaces as white space and does therefore not remove them. This makes the command not work properly.  Now an error is thrown and the user is asked to fix it.