### PR TITLE
Change SSC checklist - for a cleaner Git workflow

### DIFF
--- a/admin/checklist-submitting-SSC.md
+++ b/admin/checklist-submitting-SSC.md
@@ -3,21 +3,21 @@
 *Copy the list below to an issue when starting the process of publishing a new version of iefieldkit*
 
 - [ ] 1. **Merge to *develop*** - Merge all branches with the changes that should be included in the new version first to the `develop` branch.
-- [ ] 2. **Test in different operative systems** - This step is not necessary every time, but testing the commands in Stata on each of the PC, Mac and Linux operative systems should be done from time to time. A particularly good time to do this is after writing or editing code that depends on file paths, the console, special settings etc.
-- [ ] 3. **Update version and date** - In the `develop` branch, update the version number and date in all ado-files and all dates in all help files. See section below for details.
-- [ ] 4. **Update version locals in iefieldkit** - In the _iefieldkit.ado_ file, update the _version_ and _versionDate_ locals at the top of the file.
-- [ ] 5. **Create pull request from *develop* to *master*** - Create a pull request from the `develop` branch to the `master` branch, but do not merge it yet. We only want to merge after the content is published on SSC. The reason why we still want to create the pull request at this point is that any merge conflicts require us to make edits to the code we are sumbitting to SSC.
-- [ ] 6. **Make sure that there is no conflicts in the pull request you just created** - Make sure to include any edits this step requires you to do in the version you are sending to SSC. Do not merge yet.
-- [ ] 7. **Create a .zip file** - Create a .zip file with all ado-files and help files in the folder you just created in the archive folder. Then remove all files but the .zip file from the archive folder.
-- [ ] 8. **Merge the pull request** - Merge the pull request for this new version. It should not have any conflicts, so just merge it. Remeber to delete the *develop* branch and create a new *develop* branch from the most recent version of the *master* branch.
-- [ ] 9. **Email Prof. Baum** - Email the .zip file to **kit.baum@bc.edu**. 
+- [ ] 2. **Create version branch** - This branch _MUST_ be created from the `master` branch. Name this branch the same as the version number you are about to release. For example, `v1.1`, `v2.32` etc.
+- [ ] 3. **Merge *develop* to the version branch** - Solve all the conflicts in the version branch and then make sure that step 3.1-3.4 are done in the version branch and nowhere else.
+	- [ ] 3.1 **Test in different operative systems** - This step is not necessary every time, but testing the commands in Stata on each of the PC, Mac and Linux operative systems should be done from time to time. A particularly good time to do this is after writing or editing code that depends on file paths, the console, special settings etc. If small updates are needed, then do them in the version branch, otherwise do them in branches of the `develop` branch, merge those to `develop` and then re-merge `develop` to the version branch and test again.
+	- [ ] 3.2 **Update version and date** - In the `develop` branch, update the version number and date in all ado-files and all dates in all help files. See section below for details.
+	- [ ] 3.3 **Update version locals in iefieldkit** - In the _iefieldkit.ado_ file, update the _version_ and _versionDate_ locals at the top of the file.
+	- [ ] 3.4 **Create a .zip file** - Create a .zip file with all ado-files and help files in the folder you just created in the archive folder. Then remove all files but the .zip file from the archive folder.
+- [ ] 4. **Email Prof. Baum** - Email the .zip file created in step 3.4 to **kit.baum@bc.edu**.
 	- [ ] 9a - If any commands are added or deleted, make note of that in the email.
 	- [ ] 9b - If any of the meta info (title, description, keywords, version or authour/contact) has changed then include those updates in your email.
-- [ ] 10. **Draft release note** - Go to the [release notes](https://github.com/worldbank/iefieldkit/releases) and draft a new release note for the new version. Follow the format from previous releases with links to [issues](https://github.com/worldbank/iefieldkit/issues) solved.
-- [ ] 11. **Wait for publication confirmation** - Do not proceed pass this step until Prof. Baum has confirmed that the new version is uploaded to the servers.
-- [ ] 12. **Publish release note** - Once the new version is up on SSC, publish the release note.
-- [ ] 13. **Close issues** - When the new version is up, close all the [issues](https://github.com/worldbank/iefieldkit/issues) that was solved in the new version.
-- [ ] 14. **Send announce email** - If it is a major release (new commands or significant updates to existing commands), send an email to DIME Team to announce the new version.
+- [ ] 5. **Draft release note** - Go to the [release notes](https://github.com/worldbank/iefieldkit/releases) and draft a new release note for the new version. Follow the format from previous releases with links to [issues](https://github.com/worldbank/iefieldkit/issues) solved.
+- [ ] 6. **Wait for publication confirmation** - Do not proceed pass this step until Prof. Baum has confirmed that the new version is uploaded to the servers.
+- [ ] 7. **Merge version branch to *master*** - If step 2 and 3 was done correctly, then there should not be any merge conflicts in this step.
+- [ ] 8. **Publish release note** - Once the new version is up on SSC, publish the release note.
+- [ ] 9. **Close issues** - When the new version is up, close all the [issues](https://github.com/worldbank/iefieldkit/issues) that was solved in the new version.
+- [ ] 10. **Send announce email** - If it is a major release (new commands or significant updates to existing commands), send an email to DIME Team to announce the new version.
 
 ### Version number and dates in ado-files and help files.
 

--- a/admin/checklist-submitting-SSC.md
+++ b/admin/checklist-submitting-SSC.md
@@ -15,9 +15,10 @@
 - [ ] 5. **Draft release note** - Go to the [release notes](https://github.com/worldbank/iefieldkit/releases) and draft a new release note for the new version. Follow the format from previous releases with links to [issues](https://github.com/worldbank/iefieldkit/issues) solved.
 - [ ] 6. **Wait for publication confirmation** - Do not proceed pass this step until Prof. Baum has confirmed that the new version is uploaded to the servers.
 - [ ] 7. **Merge version branch to *master*** - If step 2 and 3 was done correctly, then there should not be any merge conflicts in this step.
-- [ ] 8. **Publish release note** - Once the new version is up on SSC, publish the release note.
-- [ ] 9. **Close issues** - When the new version is up, close all the [issues](https://github.com/worldbank/iefieldkit/issues) that was solved in the new version.
-- [ ] 10. **Send announce email** - If it is a major release (new commands or significant updates to existing commands), send an email to DIME Team to announce the new version.
+- [ ] 8. **Merge *master* to *develop*** - This step brings edits done in 3 and 3.1, as well as version updates done in 3.2 and 3.3 into the *develop* branch. If any branches created of *develop* was not included in this version, make sure to rebase then to *develop* after this merge so that big merge conflicts will be avoided in the future.
+- [ ] 9. **Publish release note** - Once the new version is up on SSC, publish the release note.
+- [ ] 10. **Close issues** - When the new version is up, close all the [issues](https://github.com/worldbank/iefieldkit/issues) that was solved in the new version.
+- [ ] 11. **Send announce email** - If it is a major release (new commands or significant updates to existing commands), send an email to DIME Team to announce the new version.
 
 ### Version number and dates in ado-files and help files.
 


### PR DESCRIPTION
What do you @luizaandrade , @bbdaniels and @mrimal think about these edits? 

The main change is that instead of merging `develop` directly to `master` you start by creating a branch of `master` that you call `v1.1`, `v2.4` etc. or whatever the version is called. Then you merge develop into that new branch. This way we can solve conflicts, add edits following testing, update meta information etc. in a branch created only for this purpose.

Since the _version branch_ is created of `master` and we merge `develop` to the _version branch_ we are de facto testing if `master` and `develop` will merge. If they do not then we will solve any conflicts in the _version branch_. Any small edits found when doing a final test can be done in the _version branch_. Once all is tested, we submit to Prof. Baum, and when it is up, we know that the _version branch_ will merge with `master` as the _version branch_ was created of that branch.

This way we do not risk sending anything to SSC that we might not be able to merge to `master` without a lot of edits.