### PR TITLE
Fix jonas err

### DIFF
--- a/src/ado_files/iecompdup.ado
+++ b/src/ado_files/iecompdup.ado
@@ -38,11 +38,11 @@
 
 					** Use that length when explicitly setting the format in
 					*  order to prevent information lost
-					tostring `varlist', replace format(%`length'.0f)
+					tostring `varlist', replace format(%`length'.0f) force
 				}
 			}
 
-			* Testing that the ID variable is a string before constinueing the command
+			* Testing that the ID variable is a string before continueing the command
 			cap confirm string variable `varlist'
 			if _rc {
 				di as error "{phang}This error message is not due to incorrect specification from you. This message follows a failed check that the command is working properly. If you get this error, please send an email to kbjarkefur@worldbank.org including the follwoing message 'ID var was not succesfully turned in to a string without information loss in iecompdup.' and include whatever other data you do not mind sharing.{p_end}"

--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -578,7 +578,15 @@
 
 				//Assign the listdiff values
 				foreach id of local list_dup_ids {
-					replace `listofdiffs' = "`difflist_`id''" if `idvar' == `id'
+
+					*Count differently if string or numeric var
+					cap confirm numeric variable `idvar'
+					if !_rc {
+						replace `listofdiffs' = "`difflist_`id''" if `idvar' == `id'
+					}
+					else {
+						replace `listofdiffs' = "`difflist_`id''" if `idvar' == "`id'"
+					}
 				}
 
 

--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -500,7 +500,14 @@
 
 			foreach id of local list_dup_ids {
 
-				count if `idvar' == `id'
+				*Count differently if string or numeric var
+				cap confirm numeric variable `idvar'
+				if !_rc {
+					count if `idvar' == `id'
+				}
+				else {
+					count if `idvar' == "`id'"
+				}
 
 				*Check if duplicated id has more than 2 duplicates, as iecompdup must be run manually to check difference when there is more than 2 observations with same ID
 				if `r(N)' > 2 {

--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -194,7 +194,15 @@
 			if `fileExists' {
 
 				*Load excel file. Load all vars as string and use metadata from Section 1
-				import excel "`folder'/iedupreport`suffix'.xlsx"	, clear firstrow case(lower)
+				import excel "`folder'/iedupreport`suffix'.xlsx"	, clear firstrow
+
+				*For backward comapitbility after allowing user to change names on
+				* vars, only use lower case, but do not change name of idvar
+				ds `idvar', not
+				foreach var in `r(varlist)' {
+					local lowcase = lower("`var'")
+					if ("`var'"!="`lowcase'") rename `var' `lowcase'  // Will throw error if name is the same
+				}
 
 				*Drop empty rows that otherwise create error in merge that requires unique key
 				tempvar count_nonmissing_values

--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -508,6 +508,9 @@
 
 			foreach id of local list_dup_ids {
 
+				*ID might have spaces, create local without spaces to use in macro names
+				local nospaceid = subinstr("`id'"," ", "",.)
+
 				*Count differently if string or numeric var
 				cap confirm numeric variable `idvar'
 				if !_rc {
@@ -535,11 +538,11 @@
 					*Truncate list when longer than 256 to fit in old Stata string formats.
 					*255-29 (characters for " ||| List truncated, use iecompdup for full list")= 226
 					if strlen("`diffvars'") > 256 {
-						local difflist_`id'  = substr("`r(diffvars)'" ,1 ,207) + " ||| List truncated, use iecompdup for full list"
+						local difflist_`nospaceid'  = substr("`r(diffvars)'" ,1 ,207) + " ||| List truncated, use iecompdup for full list"
 					}
 					else {
 						*List of diff is short enough to show in its entirety
-						local difflist_`id' "`diffvars'"
+						local difflist_`nospaceid' "`diffvars'"
 					}
 				}
 			}
@@ -590,10 +593,10 @@
 					*Count differently if string or numeric var
 					cap confirm numeric variable `idvar'
 					if !_rc {
-						replace `listofdiffs' = "`difflist_`id''" if `idvar' == `id'
+						replace `listofdiffs' = "`difflist_`nospaceid''" if `idvar' == `id'
 					}
 					else {
-						replace `listofdiffs' = "`difflist_`id''" if `idvar' == "`id'"
+						replace `listofdiffs' = "`difflist_`nospaceid''" if `idvar' == "`id'"
 					}
 				}
 


### PR DESCRIPTION
error caused by:
- new edits did not handle string ID variable well
- new edits did not handle space in ID values
- new edits made ID variable lower case when importing back from excel report, that should be done for all variables but the ID variable (for backward compatibility reasons after custom names were allowed)

Thanks @jonasguthoff for reporting!