### PR TITLE
ietestform : fix error when label is empty and imported as numeric

### DIFF
--- a/src/ado_files/ietestform.ado
+++ b/src/ado_files/ietestform.ado
@@ -213,6 +213,18 @@ qui {
 	}
 	local num_label_vars : word count `labelvars'
 
+	**Make sure all label vars are strings. Only non-string if all values are
+	* digits or all values missing. In both cases these should be changed to
+	* string, and if "." change to missing
+	foreach labelvar of local labelvars {
+
+		cap confirm string variable `labelvar'
+		if _rc {
+			tostring `labelvar', replace
+			replace `labelvar' = "" if `labelvar' == "."
+		}
+	}
+
 	*Create dummies for missing status in the label vars
 	egen 	label_count_miss	 = rowmiss(`labelvars')
 	egen 	label_count_non_miss = rownonmiss(`labelvars'), strok


### PR DESCRIPTION
Fixes issue #84 