### PR TITLE
Ietestform journal feedback

### DIFF
--- a/src/ado_files/ietestform.ado
+++ b/src/ado_files/ietestform.ado
@@ -9,7 +9,7 @@ qui {
 
 	//preserve
 
-	syntax [using/] ,  Report(string) [Surveyform(string) STATAlanguage(string) date replace]
+	syntax [using/] ,  Reportsave(string) [Surveyform(string) STATAlanguage(string) date replace]
 
 	/***********************************************
 		Test input
@@ -56,40 +56,40 @@ qui {
 	**Start by finding the position of the last forward slash. If no forward
 	* slash exist, it is zero, then replace to to string len so it is never
 	* the min() below.
-	local r_f_slash = strpos(strreverse(`"`report'"'),"\")
-	if   `r_f_slash' == 0 local r_f_slash = strlen(`"`report'"')
+	local r_f_slash = strpos(strreverse(`"`reportsave'"'),"\")
+	if   `r_f_slash' == 0 local r_f_slash = strlen(`"`reportsave'"')
 
 	**Start by finding the position of the last backward slash. If no backward
 	* slash exist, it is zero, then replace to to string len so it is never
 	* the min() below.
-	local r_b_slash = strpos(strreverse(`"`report'"'),"/")
-	if   `r_b_slash' == 0 local r_b_slash = strlen(`"`report'"')
+	local r_b_slash = strpos(strreverse(`"`reportsave'"'),"/")
+	if   `r_b_slash' == 0 local r_b_slash = strlen(`"`reportsave'"')
 
 	*Get the last slash in the report file path regardless of back or forward
-	local r_lastslash = strlen(`"`report'"')-min(`r_f_slash',`r_b_slash')
+	local r_lastslash = strlen(`"`reportsave'"')-min(`r_f_slash',`r_b_slash')
 
 	*Get the folder
-	local r_folder = substr(`"`report'"',1,`r_lastslash')
+	local r_folder = substr(`"`reportsave'"',1,`r_lastslash')
 
     *Test that the folder for the report file exists
 	mata : st_numscalar("r(dirExist)", direxists("`r_folder'"))
 	if `r(dirExist)' == 0  {
-		noi di as error `"{phang}The folder used in [`report'] does not exist.{p_end}"'
+		noi di as error `"{phang}The folder used in [`reportsave'] does not exist.{p_end}"'
 		error 601
 	}
 
 	*Get the filename and the file extension type from the report file
-	local r_filename = substr(`"`report'"',`r_lastslash'+1, .)
+	local r_filename = substr(`"`reportsave'"',`r_lastslash'+1, .)
 	local r_filenametype = substr(`"`r_filename'"',strlen(`"`r_filename'"')-strpos(strreverse(`"`r_filename'"'),".")+1,.)
 
 	*Test what the file extension type is
 	if (`"`r_filenametype'"' == "") {
 		*No file type specified, add .csv
-		local report `"`report'.csv"'
+		local report `"`reportsave'.csv"'
 	}
 	else if (`"`r_filenametype'"' != ".csv") {
 		*Incorrect file type added. Throw error
-		noi di as error `"{phang}The report  file [`report'] may only have the file extension .csv.{p_end}"'
+		noi di as error `"{phang}The report  file [`reportsave'] may only have the file extension .csv.{p_end}"'
 		error 601
 	}
 	else {
@@ -143,7 +143,6 @@ qui {
 	*Get all choice lists actaually used
 	local all_lists_used `r(all_lists_used)'
 
-
 	/***********************************************
 		Tests based on info from multiple sheets
 	***********************************************/
@@ -175,11 +174,11 @@ qui {
 	*Option date is used, add today's date to file name
 	if "`date'" != ""{
 		local date = subinstr(c(current_date)," ","",.)
-		local report = subinstr("`report'",".csv","_`date'.csv",.)
+		local report = subinstr("`reportsave'",".csv","_`date'.csv",.)
 	}
 
 	*Write the file to disk
-	noi report_file write, report_tempfile("`report_tempfile'") filepath("`report'") `replace'
+	noi report_file write, report_tempfile("`report_tempfile'") filepath("`reportsave'") `replace'
 
 	//restore
 

--- a/src/ado_files/ietestform.ado
+++ b/src/ado_files/ietestform.ado
@@ -81,11 +81,10 @@ qui {
 	*Get the filename and the file extension type from the report file
 	local r_filename = substr(`"`reportsave'"',`r_lastslash'+1, .)
 	local r_filenametype = substr(`"`r_filename'"',strlen(`"`r_filename'"')-strpos(strreverse(`"`r_filename'"'),".")+1,.)
-
 	*Test what the file extension type is
 	if (`"`r_filenametype'"' == "") {
 		*No file type specified, add .csv
-		local report `"`reportsave'.csv"'
+		local reportsave `"`reportsave'.csv"'
 	}
 	else if (`"`r_filenametype'"' != ".csv") {
 		*Incorrect file type added. Throw error
@@ -174,7 +173,7 @@ qui {
 	*Option date is used, add today's date to file name
 	if "`date'" != ""{
 		local date = subinstr(c(current_date)," ","",.)
-		local report = subinstr("`reportsave'",".csv","_`date'.csv",.)
+		local reportsave = subinstr("`reportsave'",".csv","_`date'.csv",.)
 	}
 
 	*Write the file to disk

--- a/src/ado_files/ietestform.ado
+++ b/src/ado_files/ietestform.ado
@@ -9,7 +9,7 @@ qui {
 
 	//preserve
 
-	syntax , Surveyform(string) Report(string) [STATAlanguage(string) date replace]
+	syntax [using/] ,  Report(string) [Surveyform(string) STATAlanguage(string) date replace]
 
 	/***********************************************
 		Test input
@@ -18,6 +18,18 @@ qui {
 	/*********
 		Test survey file input
 	*********/
+
+	*Test and finally combine the using and surveyform for backward compatibility
+	if `"`using'"' != "" & `"`surveyform'"'  != "" {
+		noi di as error `"{phang}Option surveyform() [`surveyform'] cannot be used together with [using `using']. surveyform() is an undocumneted option allowed for backward compatibility reasons only.{p_end}"'
+		error 198
+	}
+	else if `"`using'`surveyform'"' == "" {
+		noi di as error `"{phang}You must specifiy your survey form with [using].{p_end}"'
+		error 198
+	}
+	local surveyform `"`using'`surveyform'"'
+
 
 	* Test for form file is xls or xsls
 	local surveyformtype = substr(`"`surveyform'"',strlen(`"`surveyform'"')-strpos(strreverse(`"`surveyform'"'),".")+1,.)

--- a/src/help_files/ietestform.sthlp
+++ b/src/help_files/ietestform.sthlp
@@ -13,8 +13,7 @@ help for {hi:ietestform}
 {title:Syntax}
 
 {phang2}
-{cmdab:ietestform}
-, {cmdab:s:urveyform(}{it:"/path/to/form.xlsx"}{cmd:)} {cmdab:r:eport(}{it:"/path/to/report.csv"}{cmd:)} [{cmdab:stata:language(}{it:string}{cmd:)} {cmd:replace} {cmd:date}]
+{cmdab:ietestform} using {it:"/path/to/form.xlsx"}, {cmdab:r:eportsave(}{it:"/path/to/report.csv"}{cmd:)} [{cmdab:stata:language(}{it:string}{cmd:)} {cmd:replace} {cmd:date}]
 
 
 {marker opts}{...}
@@ -22,8 +21,8 @@ help for {hi:ietestform}
 {synopthdr:Options}
 {synoptline}
 {phang}{it:Required}{p_end}
-{synopt :{cmdab:s:urveyform(}{it:"/path/to/form.xlsx"}{cmd:)}}Specify the file path to the file with the SurveyCTO form definition.{p_end}
-{synopt :{cmdab:r:eport(}{it:"/path/to/report.csv"}{cmd:)}}Specify the file path to the .csv report you want to create listing all issues found.{p_end}
+{synopt :{cmdab:using }{it:"/path/to/form.xlsx"}}Specify the file path to the file with the SurveyCTO form definition.{p_end}
+{synopt :{cmdab:r:eportsave(}{it:"/path/to/report.csv"}{cmd:)}}Specify the file path to the .csv report you want to create listing all issues found.{p_end}
 
 {phang}{it:Optional}{p_end}
 {synopt :{cmdab:stata:language(}{it:string}{cmd:)}}Specify the name used for the Stata language label in the form definition. Default is {it:stata} which works if the column name is {it:label:stata}.{p_end}
@@ -44,9 +43,9 @@ help for {hi:ietestform}
 
 {title:Options}
 
-{phang}{cmdab:s:urveyform(}{it:"/path/to/form.xlsx"}{cmd:)} specifies the file path to the file with the SurveyCTO form definition. The form definition can be either in .xlsx or .xls format. If you are using an older version of Stata and a newer version of Excel, then you might encounter issues with the .xslx format. You can then save the file in .xls format but you might lose conditional formatting and other newer features, although no data will be lost.{p_end}
+{phang}{cmdab:using }{it:"/path/to/form.xlsx"} specifies the file path to the file with the SurveyCTO form definition. The form definition can be either in .xlsx or .xls format. If you are using an older version of Stata and a newer version of Excel, then you might encounter issues with the .xslx format. You can then save the file in .xls format but you might lose conditional formatting and other newer features, although no data will be lost. The old syntax {inp:surveyform(}{it:"/path/to/form.xlsx"}{inp:)} is still allowed for backward compatibility with earlier versions of {cmd:ietestform}.{p_end}
 
-{phang}{cmdab:r:eport(}{it:"/path/to/report.csv"}{cmd:)} specifies the file path to the .csv report you want to create listing all issues found.{p_end}
+{phang}{cmdab:r:eportsave(}{it:"/path/to/report.csv"}{cmd:)} specifies the file path to the .csv report you want to create listing all issues found.{p_end}
 
 {phang}{cmdab:stata:language(}{it:string}{cmd:)} specifies the name used for the Stata language label in the form definition. Default is {it:stata} which works if the column name is {it:label:stata}. Whatever you call your columns, do not include {it:label:} in this option, only what comes after the colon in the column name in the form definition.{p_end}
 
@@ -64,13 +63,13 @@ help for {hi:ietestform}
 
 {pstd}{hi:Example 1.}
 
-{pstd}{inp:ietestform}, {inp:surveyform(}{it:"$formdef/form.xlsx"}{inp:)} {inp:report(}{it:"$output/report.csv"}{inp:)}
+{pstd}{inp:ietestform using} {it:"$formdef/form.xlsx"}, {inp:reportsave(}{it:"$output/report.csv"}{inp:)}
 
 {pstd}This is the simplest possible way this command can be run. In this example the form {it:form.xslx} is read and all tests are applied to the form definition. A report with the name {it:report.csv} written to disk and it will include any cases caught by the command.{p_end}
 
 {pstd}{hi:Example 2.}
 
-{pstd}{inp:ietestform}, {inp:surveyform(}{it:"$formdef/form.xlsx"}{inp:)} {inp:report(}{it:"$output/report.csv"}{inp:)} {inp:date} {inp:replace}
+{pstd}{inp:ietestform using} {it:"$formdef/form.xlsx"}, {inp:reportsave(}{it:"$output/report.csv"}{inp:)} {inp:date} {inp:replace}
 
 {pstd}This example will work very similarly to Example 1. But this command will overwrite any report already in the {it:$output} folder since the option {cmd:replace} is used. Also, since the option {cmd:date} the name of the report file will be {it:report_31JAN2019.csv} (the date will obviously be updated to the current date). Since {cmd:replace} and {cmd:date} are used together, then the last report created each day will be saved for documentation.{p_end}
 


### PR DESCRIPTION
Two changes based on feedback from the Stata Journal reveiw:

- use `using` instead of `surveyform()`. Backward compatibility is built in.
- rename `report()` to `reportsave()`. Backward compatibility is automatic thanks to option name abbreviation.

I have tested this and the changes are not that big. But if someone else could test this too, then that would be great! @roshni13khincha , could you test since you have used this command before?