### PR TITLE
iecodebook: major extensions to [export] functionality

### DIFF
--- a/run/Master.do
+++ b/run/Master.do
@@ -15,8 +15,8 @@ qui {
 *******************************************************************************/
 
 	* Set root paths
-	global GitHub		""
-	global AnalyticsDB	""
+	global GitHub		"C:\Users\wb501238\Documents\GitHub"
+	global AnalyticsDB	"C:\Users\wb501238\Dropbox\WB\Analytics\DIME Analytics"
 
 	* Set up folder globals
 	global iefieldkit	"${GitHub}/iefieldkit"
@@ -28,7 +28,7 @@ qui {
 	local ieduplicates	0
 	local iecompdup		0
 	local ietestform	0
-	local iecodebook	1
+	local iecodebook	0
 	local iefieldkit	0
 	
 /*******************************************************************************

--- a/run/Master.do
+++ b/run/Master.do
@@ -15,8 +15,8 @@ qui {
 *******************************************************************************/
 
 	* Set root paths
-	global GitHub		"C:\Users\wb501238\Documents\GitHub"
-	global AnalyticsDB	"C:\Users\wb501238\Dropbox\WB\Analytics\DIME Analytics"
+	global GitHub		"C:/Users/wb501238/Documents/GitHub"
+	global AnalyticsDB	"C:/Users/wb501238/Dropbox/WB/Analytics/DIME Analytics"
 
 	* Set up folder globals
 	global iefieldkit	"${GitHub}/iefieldkit"

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -131,10 +131,28 @@
 ------------------------------------------------------------------------------*/
 	
 	* Simple run
+	tempfile auto1
+	save `auto1'
 	
+	sysuse auto
+	rename make model
+	tempfile auto2
+	
+	* Simple run
+	cap erase "${codebook}/template_apply1.xlsx"
+	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply1.xlsx", ///
 	* Run with replace
+	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply3.xlsx", ///
+		surveys(one two) replace
 	
 	* Match
+	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply2.xlsx", ///
+		surveys(one two) replace match
+		
+	* Gen
+	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply4.xlsx", ///
+		surveys(one two) replace gen(oi)
+
 		
 /*------------------------------------------------------------------------------
 	Append subcommand
@@ -149,20 +167,17 @@
 	* keepall
 
 /*******************************************************************************
-	Export final code book
+	Export final codebook
 *******************************************************************************/
 
 	sysuse auto, clear
 	cap erase "${codebook}/auto_export.xlsx"
 	iecodebook export using "${codebook}/auto_export.xlsx"						// Not sure how to test content
 	
-	* Replace option
 * Replace option ---------------------------------------------------------------
 
 	iecodebook export using "${codebook}/auto_export.xlsx", replace
 	
-	* Trim option : not working yet
-	iecodebook export using "${codebook}/auto_export.xlsx", ///
 * Trim option ------------------------------------------------------------------
 
 	iecodebook export using "${codebook}\auto_export_trim.xlsx", ///
@@ -199,12 +214,12 @@
 	
 * Textonly option --------------------------------------------------------------
 
-	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace txtonly
-cap iecodebook export using "${codebook}/auto_export.xlsx", 				replace txtonly	
+	iecodebook export using "${codebook}/auto_export.xlsx", plain(detailed) replace noexcel
+cap iecodebook export using "${codebook}/auto_export.xlsx", 				replace noexcel	
 	assert _rc == 198
-	iecodebook export using "${codebook}/auto_export.xlsx", txt(compact) 	replace
-	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace
-cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
+	iecodebook export using "${codebook}/auto_export.xlsx", plain(compact) 	replace
+	iecodebook export using "${codebook}/auto_export.xlsx", plain(detailed) replace
+cap iecodebook export using "${codebook}/auto_export.xlsx", plain(dalk) 	replace
 	assert _rc == 198
 	
 * Verify option ----------------------------------------------------------------

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -245,14 +245,27 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	cap iecodebook export "auto" using "${codebook}/auto_export.xlsx", replace
 	assert _rc == 601
 	
-	* Save option
-	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace save
+* Save option ------------------------------------------------------------------
+
+	sysuse auto, clear
+	tempfile auto
+	save 	`auto'
+	
+	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace save
+	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace saveas("auto")
+	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace saveas("${codebook}/auto")
+	
+	
 	
 	cap erase "${codebook}/auto_export.xlsx"
 	cap iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", save
 	assert _rc == 602
 	
-	* Special characters
+	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace saveas("auto_export")
+	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace saveas("auto_export2.dta")
+	
+* Special characters -----------------------------------------------------------
+
 	lab var make 	"É"
 	lab def origin  0 "ã & @", replace
 	iecodebook export using "${codebook}/auto_export.xlsx", replace

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -170,9 +170,27 @@
 							trim("${iefieldkit}/run/iecodebook_trim1.do")
 	*/
 	
-	* Signature option
+* Signature option -------------------------------------------------------------
+
+	* Should not work if there's no file and [reset] was not specified
+	cap erase  "${codebook}/auto_export-sig.txt"
 	cap iecodebook export using "${codebook}/auto_export.xlsx", replace signature
 	assert _rc == 601
+	
+	* Create it 
+	iecodebook export using "${codebook}/auto_export.xlsx", replace signature reset
+	
+	* Compare when no changes
+	iecodebook export using "${codebook}/auto_export.xlsx", replace signature
+	
+	* Compare when changes
+	preserve
+		
+		drop in 1
+		cap iecodebook export using "${codebook}/auto_export.xlsx", replace signature
+		assert _rc == 9
+		
+	restore
 	
 	* textonly option
 	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace txtonly

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -130,17 +130,20 @@
 	Template subcommand
 ------------------------------------------------------------------------------*/
 	
-	* Simple run
+	sysuse auto
 	tempfile auto1
 	save `auto1'
 	
 	sysuse auto
 	rename make model
 	tempfile auto2
+	save `auto2'
 	
 	* Simple run
 	cap erase "${codebook}/template_apply1.xlsx"
 	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply1.xlsx", ///
+		surveys(one two)
+
 	* Run with replace
 	iecodebook template `auto1' `auto2'  using "${codebook}/template_apply3.xlsx", ///
 		surveys(one two) replace

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -157,10 +157,15 @@
 	iecodebook export using "${codebook}/auto_export.xlsx"						// Not sure how to test content
 	
 	* Replace option
+* Replace option ---------------------------------------------------------------
+
 	iecodebook export using "${codebook}/auto_export.xlsx", replace
 	
 	* Trim option : not working yet
 	iecodebook export using "${codebook}/auto_export.xlsx", ///
+* Trim option ------------------------------------------------------------------
+
+	iecodebook export using "${codebook}\auto_export_trim.xlsx", ///
 							replace ///
 							trim("${iefieldkit}\run\iecodebook_trim1.do" ///
 								 "${iefieldkit}\run\iecodebook_trim2.do")
@@ -168,7 +173,7 @@
 	iecodebook export using "${codebook}/auto_export_trim.xlsx", ///			// not running
 							replace ///
 							trim("${iefieldkit}/run/iecodebook_trim1.do")
-	*/
+
 	
 * Signature option -------------------------------------------------------------
 
@@ -192,7 +197,8 @@
 		
 	restore
 	
-	* textonly option
+* Textonly option --------------------------------------------------------------
+
 	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace txtonly
 cap iecodebook export using "${codebook}/auto_export.xlsx", 				replace txtonly	
 	assert _rc == 198
@@ -201,7 +207,8 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", 				replace txtonly
 cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	assert _rc == 198
 	
-	* Verify option
+* Verify option ----------------------------------------------------------------
+
 	iecodebook export using "${codebook}/auto_export.xlsx", replace verify
 	iecodebook export using "${codebook}/auto_export.xlsx", verify
 	
@@ -229,8 +236,8 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 		
 	restore
 	
-	
-	* Use option
+* Use option -------------------------------------------------------------------
+
 	sysuse auto, clear
 	tempfile auto
 	save 	`auto'
@@ -254,15 +261,10 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace save
 	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace saveas("auto")
 	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace saveas("${codebook}/auto")
-	
-	
-	
+		
 	cap erase "${codebook}/auto_export.xlsx"
 	cap iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", save
 	assert _rc == 602
-	
-	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace saveas("auto_export")
-	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace saveas("auto_export2.dta")
 	
 * Special characters -----------------------------------------------------------
 
@@ -270,4 +272,4 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	lab def origin  0 "ã & @", replace
 	iecodebook export using "${codebook}/auto_export.xlsx", replace
 	
-	
+***************************************************************** End of do-file

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -168,5 +168,53 @@
 	iecodebook export using "${codebook}/auto_export_trim.xlsx", ///			// not running
 							replace ///
 							trim("${iefieldkit}/run/iecodebook_trim1.do")
+	*/
+	
+	* Signature option
+	cap iecodebook export using "${codebook}/auto_export.xlsx", replace signature
+	assert _rc == 601
+	
+	* textonly option
+	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace txtonly
+	iecodebook export using "${codebook}/auto_export.xlsx", txt(compact) 	replace
+	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace
+cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
+	assert _rc == 198
+	
+	* Verify option
+	iecodebook export using "${codebook}/auto_export.xlsx", replace verify
+	iecodebook export using "${codebook}/auto_export.xlsx", verify
+	
+	preserve
+	
+		drop mpg
+		iecodebook export using "${codebook}/auto_export.xlsx", verify
+		
+	restore
+	
+	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) replace verify
+	
+	* Use option
+	sysuse auto, clear
+	tempfile auto
+	save 	`auto'
+	
+	clear
+	iecodebook export `auto' using "${codebook}/auto_export.xlsx", replace
+	
+	clear
+	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace
+	
+	clear
+	cap iecodebook export "auto" using "${codebook}/auto_export.xlsx", replace
+	assert _rc == 601
+	
+	* Save option
+	iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", replace save
+	
+	cap erase "${codebook}/auto_export.xlsx"
+	cap iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", save
+	assert _rc == 602
+	
 	
 	

--- a/run/iecodebook.do
+++ b/run/iecodebook.do
@@ -159,11 +159,11 @@
 	* Replace option
 	iecodebook export using "${codebook}/auto_export.xlsx", replace
 	
-	/* Trim option : not working yet
+	* Trim option : not working yet
 	iecodebook export using "${codebook}/auto_export.xlsx", ///
 							replace ///
-							trim("${iefieldkit}/run/iecodebook_trim1" ///		// file C:\Users\wb501238\Documents\GitHub/iefieldkit/run/iecodebook_trim1.csv not found
-								 "${iefieldkit}/run/iecodebook_trim2")
+							trim("${iefieldkit}\run\iecodebook_trim1.do" ///
+								 "${iefieldkit}\run\iecodebook_trim2.do")
 	
 	iecodebook export using "${codebook}/auto_export_trim.xlsx", ///			// not running
 							replace ///
@@ -176,6 +176,8 @@
 	
 	* textonly option
 	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace txtonly
+cap iecodebook export using "${codebook}/auto_export.xlsx", 				replace txtonly	
+	assert _rc == 198
 	iecodebook export using "${codebook}/auto_export.xlsx", txt(compact) 	replace
 	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) 	replace
 cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
@@ -188,11 +190,27 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	preserve
 	
 		drop mpg
-		iecodebook export using "${codebook}/auto_export.xlsx", verify
+		cap iecodebook export using "${codebook}/auto_export.xlsx", verify
+		assert _rc == 7
 		
 	restore
 	
-	iecodebook export using "${codebook}/auto_export.xlsx", txt(detailed) replace verify
+	preserve
+	
+		drop mpg
+		cap iecodebook export using "${codebook}/auto_export.xlsx", verify replace
+		assert _rc == 7
+			
+	restore
+	
+	preserve
+	
+		label drop origin
+		cap iecodebook export using "${codebook}/auto_export.xlsx", verify replace
+		assert _rc == 7
+		
+	restore
+	
 	
 	* Use option
 	sysuse auto, clear
@@ -216,5 +234,9 @@ cap iecodebook export using "${codebook}/auto_export.xlsx", txt(dalk) 		replace
 	cap iecodebook export "${codebook}/auto" using "${codebook}/auto_export.xlsx", save
 	assert _rc == 602
 	
+	* Special characters
+	lab var make 	"É"
+	lab def origin  0 "ã & @", replace
+	iecodebook export using "${codebook}/auto_export.xlsx", replace
 	
 	

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -289,11 +289,10 @@ qui {
   }
 
   // Save data copy if requested
-  if "`save'" != "" {
-    if `"`saveas'"' != "" {
-      local savedta = `saveas'
-    }
-    save `savedta' , `replace'
+  if ("`save'" != "") | (`"`saveas'"' != "") {
+	if `"`saveas'"' != ""  local savedta = `saveas'
+  
+    save "`savedta'", `replace'
     noi di `"Copy of data saved at {browse `"`savedta'"':`savedta'}"'
   }
 

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -583,7 +583,21 @@ qui {
         use `theVallabs' , clear
           cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
           local rc = _rc
-          forvalues i = 1/10 {
+          if `rc' == 9901 {
+            di as err "There are invalid labels in your data. Correct the following:"
+            tempfile test
+            forv i = 1/`c(N)' {
+              preserve
+              keep in `i'
+              local faultLab  = label[1]
+              local faultName = lname[1]
+              
+              cap export excel label using `test'  , replace
+                if _rc != 0 di as err `"  `faultName' {tab} [`faultLab']"'
+              restore
+            }
+          } 
+          else forvalues i = 1/10 {
             if `rc' != 0 {
               sleep `i'000
               cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -56,7 +56,7 @@ cap program drop iecodebook
     local using  "`using'.xlsx"
   }
   // Throw an error if user input uses any extension other than the allowed
-  else if !inlist("`r_fileextension'",".xlsx",".xls") & !regexm("`options'","tempfile") {
+  else if !inlist("`r_fileextension'",".xlsx",".xls") & !regexm(`"`options'"',"tempfile") {
     di as error "The codebook may only have the file extension [.xslx] or [.xls]. The format [`r_fileextension'] is not allowed."
     error 601
   }

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -300,7 +300,8 @@ qui {
   // Save data copy if requested
   if "`copydata'" != "" {
     compress
-    local savedta = subinstr(`"`using'"',".xlsx",".dta",.)
+    local savedta = subinstr(`"`using'"',".xls",".dta",.)		
+    local savedta = subinstr(`"`using'"',".dtax",".dta",.)
     local hashloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
     if "`hash'" != "" {
       noisily : iecodebook_hashdata using "`hashloc'" , `reset'

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -505,7 +505,21 @@ qui {
       if "`verify'" == "" {
         cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
         local rc = _rc
-        forvalues i = 1/10 {
+        if `rc' == 9901 {
+          di as err "There are invalid labels in your data. Correct the following:"
+          tempfile test
+          forv i = 1/`c(N)' {
+            preserve
+            keep in `i'
+            local faultLab  = label[1]
+            local faultName = name[1]
+            
+            cap export excel label using `test'  , replace
+              if _rc != 0 di as err `"  `faultName' {tab} [`faultLab']"'
+            restore
+          }
+        } 
+        else forvalues i = 1/10 {
           if `rc' != 0 {
             sleep `i'000
             cap export excel "`using'" , sheet("survey") sheetreplace first(varl)

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -198,7 +198,7 @@ qui {
     foreach dofile in `trim' {
       
       // Check for dofile
-      if (`"`=substr(`"`trim'"',-3,.)'"' != ".do") {
+      if (`"`=substr("`dofile'",-3,.)'"' != ".do") {
         di as err "The specified file does not include a .do extension." ///
           "Make sure it is a Stata .do-file and you include the file extension."
         error 610

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -126,15 +126,15 @@ program iecodebook_template
 
 end
 
-// Hashdata subroutine for export --------------------------------------------------------------
+// signdata subroutine for export --------------------------------------------------------------
 
-cap prog drop iecodebook_hashdata
-prog def iecodebook_hashdata
+cap prog drop iecodebook_signdata
+prog def iecodebook_signdata
 
   syntax ///
     using/     /// Location of the desired datafile placement
   , ///
-    [reset]    /// reset dtasig if hash fails
+    [reset]    /// reset dtasig if sign fails
 
 
   // Setup
@@ -143,7 +143,7 @@ prog def iecodebook_hashdata
   // Load target data
   if `"`anything'"' != `""' use `anything' , clear
 
-  // Check existing hash, if any
+  // Check existing sign, if any
   cap datasignature confirm  using "`using'" , strict
     // If not found OR altered and no reset
     if ("`reset'" == "") {
@@ -163,7 +163,7 @@ cap program drop iecodebook_export
 
   syntax [anything] [using/] [if] [in]  ///
     , [replace] [COPYdata] [trim(string asis)]     /// User-specified options
-      [hash] [reset] [TEXTonly]         /// Hashdata options
+      [SIGNature] [reset] [TEXTonly]         /// signdata options
       [match] [template(string asis)]   // Programming options
 
 qui {
@@ -300,11 +300,11 @@ qui {
   // Save data copy if requested
   if "`copydata'" != "" {
     compress
-    local savedta = subinstr(`"`using'"',".xls",".dta",.)		
+    local savedta = subinstr(`"`using'"',".xls",".dta",.)
     local savedta = subinstr(`"`using'"',".dtax",".dta",.)
-    local hashloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
-    if "`hash'" != "" {
-      noisily : iecodebook_hashdata using "`hashloc'" , `reset'
+    local signloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
+    if "`signature'" != "" {
+      noisily : iecodebook_signdata using "`signloc'" , `reset'
     }
     save "`savedta'" , `replace'
     noi di `"Copy of data saved at {browse "`savedta'":`savedta'}"'
@@ -314,10 +314,10 @@ qui {
   if "`textonly'" != "" noisily {
     local theTextFile = subinstr(`"`using'"',".xls",".txt",.)
     local theTextFile = subinstr(`"`using'"',".xlsx",".txt",.)
-      cap log close hashdata
-      log using "`theTextFile'" , nomsg text replace name(hashdata)
+      cap log close signdata
+      log using "`theTextFile'" , nomsg text replace name(signdata)
       noisily : codebook, compact
-      log close hashdata
+      log close signdata
   }
 
   // Create XLSX file with all current/remaining variable names and labels

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -166,6 +166,10 @@ qui {
   // Return a warning if there are lots of variables
   if `c(k)' >= 1000 noi di "This dataset has `c(k)' variables. This may take a long time! Consider subsetting your variables first."
 
+  // Store current data
+  tempfile allData
+    save `allData' , emptyok replace
+      
   // Template Setup
     // Load dataset if argument
     if `"`anything'"' != "" {
@@ -179,10 +183,6 @@ qui {
       local TEMPLATE = 1                  // flag for template functions
     }
     else local TEMPLATE = 0
-
-  // Store current data and apply if/in via [marksample]
-  tempfile allData
-    save `allData' , emptyok replace
 
   // Option to [trim] variable set to variables specified in selected dofiles
   if `"`trim'"' != `""' {

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -555,7 +555,7 @@ qui {
         cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
         local rc = _rc
         if `rc' == 9901 {
-          di as err "There are invalid labels in your data. Correct the following:"
+          di as err "There are invalid variable labels in your data. Correct the following:"
           tempfile test
           forv i = 1/`c(N)' {
             preserve
@@ -584,7 +584,7 @@ qui {
           cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
           local rc = _rc
           if `rc' == 9901 {
-            di as err "There are invalid labels in your data. Correct the following:"
+            di as err "There are invalid value labels in your data. Correct the following:"
             tempfile test
             forv i = 1/`c(N)' {
               preserve

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -188,8 +188,10 @@ qui {
    // Store current data and apply if/in via [marksample]
      tempfile allData allData1
      save `allData' , emptyok replace
+     preserve
      keep in 1
      save `allData1' , emptyok replace
+     restore
 
      marksample touse
      keep if `touse'

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -234,7 +234,7 @@ qui {
     }
 
     // Clean up common characters
-    foreach character in , . < > / ? [ ] | & ! ^ + - : * = ( ) "{" "}" "`" "'" {
+    foreach character in , . < > / [ ] | & ! ^ + - : = ( ) "{" "}" "`" "'" {
       replace v1 = subinstr(v1,"`character'"," ",.)
     }
 
@@ -248,6 +248,14 @@ qui {
       drop i j v1
       drop if `v' == ""
       duplicates drop
+
+    // Make sure there are no hanging *
+      local length = substr("`: type `v''",4,.)
+      local stars = "*"
+      forv i = 1/`length' {
+        replace `v' = "" if `v' == "`stars'"
+        local stars "`stars'*"
+      }
 
     // Cheat to get all the variables in the dataset
     foreach item in `theVarlist' {

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -241,6 +241,10 @@ qui {
     foreach character in , . < > / [ ] | & ! ^ + - : = ( ) "{" "}" "`" "'" {
       replace v1 = subinstr(v1,"`character'"," ",.)
     }
+      replace v1 = subinstr(v1, char(34), "", .) // Remove " sign
+      replace v1 = subinstr(v1, char(96), "", .) // Remove ` sign
+      replace v1 = subinstr(v1, char(36), "", .) // Remove $ sign
+      replace v1 = subinstr(v1, char(10), "", .) // Remove line end
 
     // Reshape one word per line
       split v1
@@ -260,6 +264,8 @@ qui {
         replace `v' = "" if `v' == "`stars'"
         local stars "`stars'*"
       }
+      replace `v' = subinstr(`v',"*"," * ",.) // Fix issues with multiplication
+
 
     // Cheat to get all the variables in the dataset
     foreach item in `theVarlist' {

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -421,40 +421,15 @@ qui {
 
     // Create value labels sheet
 
-      // Fill temp dataset with value labels
-      foreach var of varlist * {
-        use `var' using `allData1' , clear
-        local theLabel : value label `var'
-        if "`theLabel'" != "" {
-          cap label save `theLabel' using `theLabels' ,replace
-          if _rc==0 {
-            import delimited using `theLabels' , clear delimit(", modify", asstring)
-            append using `theCommands'
-              save `theCommands' , replace emptyok
-          }
-        }
-      }
-
-      // Clean up value labels for export - use SurveyCTO syntax for sheet names and column names
-      use `theCommands' , clear
-      count
-      if `r(N)' > 0 {
-        duplicates drop
-        drop v2
-        replace v1 = trim(subinstr(v1,"label define","",.))
-        split v1 , parse(`"""')
-        split v11 , parse(`" "')
-        keep v111 v112 v12
-        order v111 v112 v12
-
-        rename (v111 v112 v12)(list_name value label)
-      }
-      else {
-        set obs 1
-        gen list_name = ""
-        gen value = ""
-        gen label = ""
-      }
+    // Clean up value labels for export - use SurveyCTO syntax for sheet names and column names
+    uselabel _all, clear
+      ren lname list_name
+      drop trunc
+      tostring value , replace 
+    count
+    if `r(N)' == 0 {
+      set obs 1
+    }
 
       // Export value labels to "choices" sheet
       cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -288,13 +288,6 @@ qui {
         error 198
       }
       keep `theKeepList' // Keep only variables mentioned in the dofiles
-      compress
-      local savedta = subinstr(`"`using'"',".xls",".dta",.)
-      local savedta = subinstr(`"`using'"',".dtax",".dta",.)
-      if "`hash'" != "" {
-        noisily : iecodebook_hashdata using "`savedta'" , `textonly' `reset'
-      }
-      save "`savedta'" , replace
   } // End [trim] option
 
   // Save data copy if requested

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -144,14 +144,14 @@ prog def iecodebook_hashdata
   if `"`anything'"' != `""' use `anything' , clear
 
   // Check existing hash, if any
-  cap datasignature confirm  using "`using'sig" , strict
+  cap datasignature confirm  using "`using'" , strict
     // If not found OR altered and no reset
     if ("`reset'" == "") {
-      datasignature confirm using "`using'sig" , strict
+      datasignature confirm using "`using'" , strict
     }
     // If altered OR missing AND reset ordered
     else {
-      datasignature set , saving("`using'sig" , replace) reset
+      datasignature set , saving("`using'" , replace) reset
     }
 
 end
@@ -281,12 +281,13 @@ qui {
       save "`savedta'" , replace
   } // End [trim] option
 
-  // Save data copy if requestedx
+  // Save data copy if requested
   if "`copydata'" != "" {
     compress
     local savedta = subinstr(`"`using'"',".xlsx",".dta",.)
+    local hashloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
     if "`hash'" != "" {
-      noisily : iecodebook_hashdata using "`savedta'" , `reset'
+      noisily : iecodebook_hashdata using "`hashloc'" , `reset'
     }
     save "`savedta'" , `replace'
   }

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -188,6 +188,8 @@ qui {
    // Store current data and apply if/in via [marksample]
      tempfile allData
      save `allData' , emptyok replace
+     keep in 1
+     save `allData1' , emptyok replace
 
      marksample touse
      keep if `touse'
@@ -421,7 +423,7 @@ qui {
 
       // Fill temp dataset with value labels
       foreach var of varlist * {
-        use `var' using `allData' in 1 , clear
+        use `var' using `allData1' , clear
         local theLabel : value label `var'
         if "`theLabel'" != "" {
           cap label save `theLabel' using `theLabels' ,replace

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -152,7 +152,7 @@ end
 cap program drop iecodebook_export
   program    iecodebook_export
 
-  syntax [anything] [using/] [if] [in]  ///
+  syntax [anything] [using/]  ///
     , [replace] [COPYdata] [trim(string asis)]     /// User-specified options
       [SIGNature] [reset] [TEXTonly] [verify]      /// Signature and verify options
       [match] [template(string asis)] [tempfile]    // Programming options
@@ -179,10 +179,6 @@ qui {
   // Store current data and apply if/in via [marksample]
   tempfile allData
     save `allData' , emptyok replace
-
-    marksample touse
-    keep if `touse'
-     drop `touse'
 
   // Option to [trim] variable set to variables specified in selected dofiles
   if `"`trim'"' != `""' {
@@ -546,6 +542,7 @@ qui {
       else {
         noi di "Existing codebook and data structure verified to match."
       }
+  use `allData' , clear
 } // end qui
 
 end

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -395,7 +395,14 @@ qui {
         restore
         }
       }
+
+    if `QUITFLAG' == 1 {
+      di as err ""
+      di as err "Differences were encountered between the existing data and the codebook."
+      di as err "{bf:iecodebook} will now exit."
+      error 7
     }
+    } // end VERIFY option
 
     // Write to new dataset
 

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -134,7 +134,7 @@ prog def iecodebook_hashdata
   syntax ///
     using/     /// Location of the desired datafile placement
   , ///
-    [reset]    /// reset dtasig if has fails
+    [reset]    /// reset dtasig if hash fails
 
 
   // Setup

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -295,7 +295,8 @@ qui {
 
   // Write text codebook if requested
   if "`textonly'" != "" noisily {
-    local theTextFile = subinstr(`"`using'"',".dta",".txt",.)
+    local theTextFile = subinstr(`"`using'"',".xls",".txt",.)
+    local theTextFile = subinstr(`"`using'"',".xlsx",".txt",.)
       cap log close hashdata
       log using "`theTextFile'" , nomsg text replace name(hashdata)
       noisily : codebook, compact

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -384,6 +384,7 @@ qui {
             di as err `"  it was `theOldLabel' and is now `theLabel'."'
           }
           local theOldChoices = choices[1]
+          if "`theOldChoices'" == "." local theOldChoices ""
           if "`theOldChoices'" != "`theChoices'" {
             local QUITFLAG = 1
             di as err "The value label of {bf:`theVariable'} has changed:"

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -264,8 +264,6 @@ qui {
         replace `v' = "" if `v' == "`stars'"
         local stars "`stars'*"
       }
-      replace `v' = subinstr(`v',"*"," * ",.) // Fix issues with multiplication
-
 
     // Cheat to get all the variables in the dataset
     foreach item in `theVarlist' {

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -157,7 +157,7 @@ cap program drop iecodebook_export
   program    iecodebook_export
 
   syntax [anything] [using/]  ///
-    , [replace] [save] [trim(string asis)]     /// User-specified options
+    , [replace] [save] [saveas(string asis)] [trim(string asis)]     /// User-specified options
       [SIGNature] [reset] [PLAINtext(string)] [noexcel] [verify]      /// Signature and verify options
       [match] [template(string asis)] [tempfile]    // Programming options
 
@@ -284,14 +284,17 @@ qui {
 
   // Check signature if requested
   if "`signature'" != "" {
-    noisily : iecodebook_signdata using "`signloc'" , `reset'
-    noi di `"Data signature can be found at at {browse "`signloc'":`signloc'}"'
+    noisily : iecodebook_signdata using `"`signloc'"' , `reset'
+    noi di `"Data signature can be found at at {browse `"`signloc'"':`signloc'}"'
   }
 
   // Save data copy if requested
   if "`save'" != "" {
-    save "`savedta'" , `replace'
-    noi di `"Copy of data saved at {browse "`savedta'":`savedta'}"'
+    if `"`saveas'"' != "" {
+      local savedta = `saveas'
+    }
+    save `savedta' , `replace'
+    noi di `"Copy of data saved at {browse `"`savedta'"':`savedta'}"'
   }
 
 	if !missing("`verify'") & !missing("`excel'") { 

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -186,7 +186,7 @@ qui {
     else local TEMPLATE = 0
 
    // Store current data and apply if/in via [marksample]
-     tempfile allData
+     tempfile allData allData1
      save `allData' , emptyok replace
      keep in 1
      save `allData1' , emptyok replace

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -138,6 +138,10 @@ prog def iecodebook_signdata
   cap datasignature confirm  using "`using'" , strict
     // If not found OR altered and no reset
     if ("`reset'" == "") {
+      if _rc == 601 {
+        di as err "There is no datasignature created yet." ///
+          " Specify the [reset] option to initialize one."
+      }
       datasignature confirm using "`using'" , strict
     }
     // If altered OR missing

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -134,20 +134,13 @@ prog def iecodebook_signdata
   , ///
     [reset]    /// reset dtasig if sign fails
 
-
-  // Setup
-  preserve // Respect current data
-
-  // Load target data
-  if `"`anything'"' != `""' use `anything' , clear
-
   // Check existing sign, if any
   cap datasignature confirm  using "`using'" , strict
     // If not found OR altered and no reset
     if ("`reset'" == "") {
       datasignature confirm using "`using'" , strict
     }
-    // If altered OR missing AND reset ordered
+    // If altered OR missing
     else {
       datasignature set , saving("`using'" , replace) reset
     }
@@ -274,15 +267,20 @@ qui {
       keep `theKeepList' // Keep only variables mentioned in the dofiles
   } // End [trim] option
 
+  // Prepare to save and sign
+  compress
+    local savedta = subinstr(`"`using'"',".xls",".dta",.)
+    local savedta = subinstr(`"`savedta'"',".dtax",".dta",.)
+    local signloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
+
+  // Check signature if requested
+  if "`signature'" != "" {
+    noisily : iecodebook_signdata using "`signloc'" , `reset'
+    noi di `"Data signature can be found at at {browse "`signloc'":`signloc'}"'
+  }
+
   // Save data copy if requested
   if "`copydata'" != "" {
-    compress
-    local savedta = subinstr(`"`using'"',".xls",".dta",.)
-    local savedta = subinstr(`"`using'"',".dtax",".dta",.)
-    local signloc = subinstr(`"`savedta'"',".dta","-sig.txt",.)
-    if "`signature'" != "" {
-      noisily : iecodebook_signdata using "`signloc'" , `reset'
-    }
     save "`savedta'" , `replace'
     noi di `"Copy of data saved at {browse "`savedta'":`savedta'}"'
   }

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -238,7 +238,7 @@ qui {
     }
 
     // Clean up common characters
-    foreach character in , . < > / [ ] | & ! ^ + - : = ( ) "{" "}" "`" "'" {
+    foreach character in , . < > / [ ] | & ! ^ + - : = ( ) # "{" "}" "`" "'" {
       replace v1 = subinstr(v1,"`character'"," ",.)
     }
       replace v1 = subinstr(v1, char(34), "", .) // Remove " sign

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -153,7 +153,7 @@ cap program drop iecodebook_export
   program    iecodebook_export
 
   syntax [anything] [using/]  ///
-    , [replace] [COPYdata] [trim(string asis)]     /// User-specified options
+    , [replace] [save] [trim(string asis)]     /// User-specified options
       [SIGNature] [reset] [TEXTonly] [verify]      /// Signature and verify options
       [match] [template(string asis)] [tempfile]    // Programming options
 
@@ -276,7 +276,7 @@ qui {
   }
 
   // Save data copy if requested
-  if "`copydata'" != "" {
+  if "`save'" != "" {
     save "`savedta'" , `replace'
     noi di `"Copy of data saved at {browse "`savedta'":`savedta'}"'
   }

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -63,7 +63,7 @@ cap program drop iecodebook
 
 
   // Throw error on [template] if codebook cannot be created
-   if inlist("`subcommand'","template","export") & !inlist(`"`options'"',"replace","verify") {
+   if inlist("`subcommand'","template","export") & !regexm(`"`options'"',"replace") & !regexm(`"`options'"',"verify") {
 
     cap confirm file "`using'"
     if (_rc == 0) & (!strpos(`"`options'"',"replace")) {
@@ -287,30 +287,31 @@ qui {
     noi di `"Copy of data saved at {browse "`savedta'":`savedta'}"'
   }
 
-  // Write text codebook if requested
+  // Write text codebook ONLY if requested
   if "`textonly'" != "" noisily {
+    if "`verify'" != "" di as err "The [textonly] and [verify] options cannot be combined."
+    if "`verify'" != "" err 184
     local theTextFile = subinstr(`"`using'"',".xls",".txt",.)
     local theTextFile = subinstr(`"`using'"',".xlsx",".txt",.)
       cap log close signdata
       log using "`theTextFile'" , nomsg text replace name(signdata)
       noisily : codebook, compact
       log close signdata
+    exit
   }
 
-  // Create XLSX file with all current/remaining variable names and labels
-  if "`textonly'" == "" {
+  // Otherwise, write XLSX file and VERIFY if requested
+    // Record dataset info
 
-      // Record dataset info
+      local allVariables
+      local allLabels
+      local allChoices
 
-        local allVariables
-        local allLabels
-        local allChoices
-
-        foreach var of varlist * {
-          local theVariable = "`var'"
-          local theLabel    : var label `var'
-          local theChoices  : val label `var'
-          local theType     : type `var'
+      foreach var of varlist * {
+        local theVariable = "`var'"
+        local theLabel    : var label `var'
+        local theChoices  : val label `var'
+        local theType     : type `var'
 
         local allVariables   `"`allVariables'   `theVariable'   "'
         local allLabels      `"`allLabels'      "`theLabel'"    "'
@@ -328,147 +329,148 @@ qui {
       if `r(N)' == 0 {
         set obs 1
       }
+
       tempfile theVallabs
         save `theVallabs' , replace
 
-  // Get existing codebook if VERIFY option and check variable lists
-  if "`verify'" != "" {
-  local QUITFLAG = 0
-    import excel "`using'", clear first sheet("survey")
-    levelsof name , local(oldVars) clean
-    local both : list allVariables & oldVars
-
-    // Check excess variables in data
-    local extra : list allVariables - oldVars
-    if "`extra'" != "" {
-      local QUITFLAG = 1
-      noi di as err "The following variables are in this data but not the codebook:"
-      foreach item in `extra' {
-        noi di "  `item'"
-      }
-    }
-
-    // Check excess variables in codebook
-    local missing : list oldVars - allVariables
-    if "`missing'" != "" {
-      local QUITFLAG = 1
-      noi di as err "The following variables are in the codebook but not the data:"
-      foreach item in `missing' {
-        noi di "  `item'"
-      }
-    }
-
-    // Check attributes of all overlapping variables
-    local theN : word count `allVariables'
-    forvalues i = 1/`theN' {
-      local theVariable : word `i' of `allVariables'
-      local theLabel    : word `i' of `allLabels'
-      local theChoices  : word `i' of `allChoices'
-      local theType     : word `i' of `allTypes'
-
-      // Proceed to all checks if variable is in both locations
-      if strpos("`both'"," `theVariable' ") {
-      preserve
-        keep if name == "`theVariable'"
-
-        local theOldType = type[1]
-        if "`theOldType'" != "`theType'" {
-          local QUITFLAG = 1
-          di as err "The type of {bf:`theVariable'} has changed:"
-          di as err `"  it was `theOldType' and is now `theType'."'
-        }
-        local theOldLabel = label[1]
-        if "`theOldLabel'" != "`theLabel'" {
-          local QUITFLAG = 1
-          di as err "The label of {bf:`theVariable'} has changed:"
-          di as err `"  it was `theOldLabel' and is now `theLabel'."'
-        }
-        local theOldChoices = choices[1]
-        if "`theOldChoices'" != "`theChoices'" {
-          local QUITFLAG = 1
-          di as err "The value label of {bf:`theVariable'} has changed:"
-          di as err `"  it was `theOldChoices' and is now `theChoices'."'
-        }
-      restore
-      }
-    }
-
-    // Check all value labels
-    import excel "`using'", clear first sheet("choices")
-      ren label label_old
-      merge 1:1 list_name value using `theVallabs'
-
-      qui count
-      forv i = 1/`r(N)' {
-        local list = list_name[`i']
-        local value = value[`i']
-        local oldlab = label_old[`i']
-        local lab = label[`i']
-        local merge = _merge[`i']
-
-        if `merge' == 1 {
-        local QUITFLAG = 1
-          di as err `"Choice list `list' = `value' (`oldlab') was found in the existing codebook but not the data."'
-        }
-        else if `merge' == 2 {
-        local QUITFLAG = 1
-          di as err `"Choice list `list' = `value' (`lab') was found in the data but not the existing codebook."'
-        }
-        else if `"`oldlab'"' != `"`lab'"' {
-        local QUITFLAG = 1
-          di as err `"Choice list `list' = `value' is (`oldlab') in the codebook but (`lab') in the data."'
-        }
-      }
-
-    // Throw error if any differences found
-    if `QUITFLAG' == 1 {
-      di as err ""
-      di as err "Differences were encountered between the existing data and the codebook."
-      di as err "{bf:iecodebook} will now exit."
-      error 7
-    }
-  } // end VERIFY option for variable characteristics
-
-  // Create XLSX file with all current/remaining variable names and labels
-  clear
-
-    local theN : word count `allVariables'
-
-    local templateN ""
-    if `TEMPLATE' & "`match'" == "" {
+    // Get existing codebook if VERIFY option and check variable lists
+    if "`verify'" != "" {
+    local QUITFLAG = 0
       import excel "`using'", clear first sheet("survey")
+      levelsof name , local(oldVars) clean
+      local both : list allVariables & oldVars
 
-      count
-      local templateN "+ `r(N)'"
-    }
+      // Check excess variables in data
+      local extra : list allVariables - oldVars
+      if "`extra'" != "" {
+        local QUITFLAG = 1
+        noi di as err "The following variables are in this data but not the codebook:"
+        foreach item in `extra' {
+          noi di "  `item'"
+        }
+      }
 
-    set obs `=`theN' `templateN''
+      // Check excess variables in codebook
+      local missing : list oldVars - allVariables
+      if "`missing'" != "" {
+        local QUITFLAG = 1
+        noi di as err "The following variables are in the codebook but not the data:"
+        foreach item in `missing' {
+          noi di "  `item'"
+        }
+      }
 
-    gen name`template' = ""
-      label var name`template' "name`template_colon'"
-    gen label`template' = ""
-      label var label`template' "label`template_colon'"
-    gen type`template' = ""
-      label var type`template' "type`template_colon'"
-    gen choices`template' = ""
-      label var choices`template' "choices`template_colon'"
-    if `TEMPLATE' gen recode`template' = ""
-      if `TEMPLATE' label var recode`template' "recode`template_colon'"
+      // Check attributes of all overlapping variables
+      local theN : word count `allVariables'
+      forvalues i = 1/`theN' {
+        local theVariable : word `i' of `allVariables'
+        local theLabel    : word `i' of `allLabels'
+        local theChoices  : word `i' of `allChoices'
+        local theType     : word `i' of `allTypes'
 
-    forvalues i = 1/`theN' {
-      local theVariable : word `i' of `allVariables'
-      local theLabel    : word `i' of `allLabels'
-      local theChoices  : word `i' of `allChoices'
-      local theType     : word `i' of `allTypes'
+        // Proceed to all checks if variable is in both locations
+        if strpos("`both'"," `theVariable' ") {
+        preserve
+          keep if name == "`theVariable'"
 
-      replace name`template'    = `"`theVariable'"'  in `=`i'`templateN''
-      replace label`template'   = `"`theLabel'"'     in `=`i'`templateN''
-      replace type`template'    = `"`theType'"'      in `=`i'`templateN''
-      replace choices`template' = `"`theChoices'"'   in `=`i'`templateN''
-    }
+          local theOldType = type[1]
+          if "`theOldType'" != "`theType'" {
+            local QUITFLAG = 1
+            di as err "The type of {bf:`theVariable'} has changed:"
+            di as err `"  it was `theOldType' and is now `theType'."'
+          }
+          local theOldLabel = label[1]
+          if "`theOldLabel'" != "`theLabel'" {
+            local QUITFLAG = 1
+            di as err "The label of {bf:`theVariable'} has changed:"
+            di as err `"  it was `theOldLabel' and is now `theLabel'."'
+          }
+          local theOldChoices = choices[1]
+          if "`theOldChoices'" != "`theChoices'" {
+            local QUITFLAG = 1
+            di as err "The value label of {bf:`theVariable'} has changed:"
+            di as err `"  it was `theOldChoices' and is now `theChoices'."'
+          }
+        restore
+        }
+      }
 
-    if `TEMPLATE' & "`match'" != "" {
-      tempfile newdata
+      // Check all value labels
+      import excel "`using'", clear first sheet("choices")
+        ren label label_old
+        merge 1:1 list_name value using `theVallabs'
+
+        qui count
+        forv i = 1/`r(N)' {
+          local list = list_name[`i']
+          local value = value[`i']
+          local oldlab = label_old[`i']
+          local lab = label[`i']
+          local merge = _merge[`i']
+
+          if `merge' == 1 {
+          local QUITFLAG = 1
+            di as err `"Choice list `list' = `value' (`oldlab') was found in the existing codebook but not the data."'
+          }
+          else if `merge' == 2 {
+          local QUITFLAG = 1
+            di as err `"Choice list `list' = `value' (`lab') was found in the data but not the existing codebook."'
+          }
+          else if `"`oldlab'"' != `"`lab'"' {
+          local QUITFLAG = 1
+            di as err `"Choice list `list' = `value' is (`oldlab') in the codebook but (`lab') in the data."'
+          }
+        }
+
+      // Throw error if any differences found
+      if `QUITFLAG' == 1 {
+        di as err ""
+        di as err "Differences were encountered between the existing data and the codebook."
+        di as err "{bf:iecodebook} will now exit."
+        error 7
+      }
+    } // end VERIFY option for variable characteristics
+
+    // Create XLSX file with all current/remaining variable names and labels
+    clear
+
+      local theN : word count `allVariables'
+
+      local templateN ""
+      if `TEMPLATE' & "`match'" == "" {
+        import excel "`using'", clear first sheet("survey")
+
+        count
+        local templateN "+ `r(N)'"
+      }
+
+      set obs `=`theN' `templateN''
+
+      gen name`template' = ""
+        label var name`template' "name`template_colon'"
+      gen label`template' = ""
+        label var label`template' "label`template_colon'"
+      gen type`template' = ""
+        label var type`template' "type`template_colon'"
+      gen choices`template' = ""
+        label var choices`template' "choices`template_colon'"
+      if `TEMPLATE' gen recode`template' = ""
+        if `TEMPLATE' label var recode`template' "recode`template_colon'"
+
+      forvalues i = 1/`theN' {
+        local theVariable : word `i' of `allVariables'
+        local theLabel    : word `i' of `allLabels'
+        local theChoices  : word `i' of `allChoices'
+        local theType     : word `i' of `allTypes'
+
+        replace name`template'    = `"`theVariable'"'  in `=`i'`templateN''
+        replace label`template'   = `"`theLabel'"'     in `=`i'`templateN''
+        replace type`template'    = `"`theType'"'      in `=`i'`templateN''
+        replace choices`template' = `"`theChoices'"'   in `=`i'`templateN''
+      }
+
+      if `TEMPLATE' & "`match'" != "" {
+        tempfile newdata
         save `newdata' , replace
 
         import excel "`using'", clear first sheet("survey")
@@ -478,64 +480,65 @@ qui {
           local theNames = "`r(varlist)'"
           label var name`template' "name`template_colon'"
 
-          // Allow matching for more rounds
-          local nNames : list sizeof theNames
-          if `nNames' > 2 {
-            forvalues i = 2/`nNames' {
-              replace name`template' = `: word `i' of `theNames'' if name`template' == ""
-            }
+        // Allow matching for more rounds
+        local nNames : list sizeof theNames
+        if `nNames' > 2 {
+          forvalues i = 2/`nNames' {
+            replace name`template' = `: word `i' of `theNames'' if name`template' == ""
           }
+        }
 
-          tempvar order
-          gen `order' = _n
+        tempvar order
+        gen `order' = _n
 
         merge m:1 name`template' using `newdata' , nogen
         replace name`template' = "" if type`template' == ""
 
-          sort `order'
-          drop `order'
+        sort `order'
+        drop `order'
       }
 
       // Export variable information to "survey" sheet
-      cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
-      local rc = _rc
-      forvalues i = 1/10 {
-        if `rc' != 0 {
-          sleep `i'000
-          cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
+      if "`verify'" == "" {
+        cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
+        local rc = _rc
+        forvalues i = 1/10 {
+          if `rc' != 0 {
+            sleep `i'000
+            cap export excel "`using'" , sheet("survey") sheetreplace first(varl)
+            local rc = _rc
+          }
+        }
+        if `rc' != 0 di as err "A codebook didn't write properly. This can be caused by file syncing the file or having the file open."
+        if `rc' != 0 di as err "If the file is not currently open, consider turning file syncing off or using a non-synced location. You may need to delete the file and try again."
+        if `rc' != 0 error 603
+
+        // Export value labels to "choices" sheet
+        use `theVallabs' , clear
+          cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
           local rc = _rc
+          forvalues i = 1/10 {
+            if `rc' != 0 {
+              sleep `i'000
+              cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
+              local rc = _rc
+            }
+          }
+          if `rc' != 0 di as err "A codebook didn't write properly. This can be caused by Dropbox syncing the file or having the file open."
+          if `rc' != 0 di as err "Consider turning Dropbox syncing off or using a non-Dropbox location. You may need to delete the file and try again."
+          if `rc' != 0 error 603
+
+        // Reload original data
+        use "`allData'" , clear
+
+        // Success message
+        if `c(N)' > 1 & "`tempfile'" == "" {
+          noi di `"Codebook for data created using {browse "`using'":`using'}
         }
       }
-
-    if `rc' != 0 di as err "A codebook didn't write properly. This can be caused by file syncing the file or having the file open."
-    if `rc' != 0 di as err "If the file is not currently open, consider turning file syncing off or using a non-synced location. You may need to delete the file and try again."
-    if `rc' != 0 error 603
-
-    // Create value labels sheet
-
-    // Export value labels to "choices" sheet
-    use `theVallabs' , clear
-    cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
-    local rc = _rc
-    forvalues i = 1/10 {
-      if `rc' != 0 {
-        sleep `i'000
-        cap export excel "`using'" , sheet("choices`template_us'") sheetreplace first(var)
-        local rc = _rc
+      else {
+        noi di "Existing codebook and data structure verified to match."
       }
-      if `rc' != 0 di as err "A codebook didn't write properly. This can be caused by Dropbox syncing the file or having the file open."
-      if `rc' != 0 di as err "Consider turning Dropbox syncing off or using a non-Dropbox location. You may need to delete the file and try again."
-      if `rc' != 0 error 603
-
-  // Reload original data
-  use "`allData'" , clear
-  // Success message
-
-  if `c(N)' > 1 & "`tempfile'" == "" {
-    noi di `"Codebook for data created using {browse "`using'":`using'}
-  }
-  } // End textonly flag
-
 } // end qui
 
 end

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -196,6 +196,15 @@ qui {
 
     // Stack up all the lines of code from all the dofiles in a dataset
     foreach dofile in `trim' {
+      
+      // Check for dofile
+      if (`"`=substr(`"`trim'"',-3,.)'"' != ".do") {
+        di as err "The specified file does not include a .do extension." ///
+          "Make sure it is a Stata .do-file and you include the file extension."
+        error 610
+      }
+      
+      // Load dofile contents as data
       import delimited "`dofile'" , clear varnames(nonames)
 
       unab allv : *

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -319,6 +319,14 @@ qui {
 
     // Get all value labels for export
     uselabel _all, clear
+      // Handle if no labels in dataset
+      if c(k) == 0 {
+        gen trunc = ""
+        gen lname = ""
+        gen value = ""
+        gen label = ""
+      }
+
       ren lname list_name
       drop trunc
       tostring value , replace

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -80,7 +80,7 @@ and optionally reduces the dataset to only the variables used in a set of specif
 
 {p 2 4}{cmdab:iecodebook export} ["/path/to/data"] {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
-{p 2 4}, [{bf:replace}] [{opt copy:data}] [{bf:verify}] [{opt text:only}] {break}
+{p 2 4}, [{bf:replace}] [{opt save}] [{bf:verify}] [{opt text:only}] {break}
     [{opt sign:ature}] [{opt reset}] {break}
     [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
@@ -146,7 +146,7 @@ For example, appending a same-named string variable to a numeric variable may ca
 {synoptline}
 {synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook or dataset.{p_end}
 {break}
-{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook,
+{synopt:{opt save}}This option requests that a the data be saved at the same location as the codebook,
 with the same name as the codebook.{p_end}
 {break}
 {synopt:{opt verify}}This option orders {cmdab:iecodebook export} to confirm that the current data precisely matches an existing codebook.
@@ -157,7 +157,7 @@ A new codebook will not be written in this case.{p_end}
 This cannot be combined with {bf:verify}.{p_end}
 {break}
 {synopt:{opt sign:ature}}This option requests that a {help datasignature} be verified
-in the same destination folder as the codebook and/or data copy are placed,
+in the same destination folder as the codebook and/or data are saved,
 and will return an error if a datasignature file is not found or is different,
 guaranteeing data has not changed since the last {bf:reset} of the signature.{p_end}
 {break}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -79,7 +79,8 @@ and optionally reduces the dataset to only the variables used in a set of specif
 
 {p 2 4}{cmdab:iecodebook export} ["/path/to/data"] {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
-{p 2 4}, [{bf:replace}] [{bf:verify}] [{opt text:only}] [{opt copy:data}] [{opt sign:ature}] [{opt reset}] {break}
+{p 2 4}, [{bf:replace}] [{opt copy:data}] [{bf:verify}] [{opt text:only}] {break}
+    [{opt sign:ature}] [{opt reset}] {break}
     [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
 {hline}
@@ -144,12 +145,13 @@ For example, appending a same-named string variable to a numeric variable may ca
 {synoptline}
 {synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook or dataset.{p_end}
 {break}
+{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook, with the same name.{p_end}
+{break}
 {synopt:{opt verify}}This option orders {cmdab:iecodebook export} to confirm that the current data precisely matches an existing codebook.
 It will break with an error and describe all changes if there are any differences between the two.{p_end}
 {break}
-{synopt:{opt text:only}}This option requests that the codebook be created as a plaintext file.{p_end}
-{break}
-{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook, with the same name.{p_end}
+{synopt:{opt text:only}}This option requests that the codebook be created as a plaintext file.
+This cannot be combined with {bf:verify}.{p_end}
 {break}
 {synopt:{opt sign:ature}}This option requests that a {help datasignature} be verified
 in the same destination folder as the codebook and/or data copy are placed,

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -150,6 +150,9 @@ For example, appending a same-named string variable to a numeric variable may ca
 {synopt:{opt save}}This option requests that a the data be saved at the same location as the codebook,
 with the same name as the codebook.{p_end}
 {break}
+{synopt:{opt saveas()}}This option requests that a the data be saved at the specified location,
+overwriting the codebook name.{p_end}
+{break}
 {synopt:{opt verify}}This option orders {cmdab:iecodebook export} to confirm that the current data precisely matches an existing codebook.
 It will break with an error and describe all changes if there are any differences between the two.
 A new codebook will not be written in this case.{p_end}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -82,7 +82,7 @@ and optionally reduces the dataset to only the variables used in a set of specif
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
 {p 2 4}, [{bf:replace}] [{opt save}] [{bf:verify}] {break}
     [{opt sign:ature}] [{opt reset}] {break}
-	[{opt txt({it:compact} | {it:detailed})}] [{opt txtonly}] {break}
+	[{opt plain:text}({it:compact} | {it:detailed})] [{opt noexcel}] {break}
     [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
 {hline}
@@ -157,7 +157,7 @@ overwriting the codebook name.{p_end}
 It will break with an error and describe all changes if there are any differences between the two.
 A new codebook will not be written in this case.{p_end}
 {break}
-{synopt:{opt plain:text({it:compact} | {it:detailed})}}This option requests that the codebook be created as a plaintext file.
+{synopt:{opt plain:text}({it:compact} | {it:detailed})}This option requests that the codebook be created as a plaintext file.
 This file contains the default output of {help codebook} if argument {it:detailed}} is used, 
 and the compact output of {help codebook} if argument {it:compact} is used.
 Only one of the arguments can be used}.{p_end}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -74,11 +74,12 @@ and optionally produces an export version of the dataset with only variables use
 [{bf:report replace keepall}] {p_end}
 
 
-{dlgtab 0:Export: Creating a full codebook of the current data}
+{dlgtab 0:Export: Creating codebooks and signatures for datasets}
 
-{p 2 4}{cmdab:iecodebook export} {break}
+{p 2 4}{cmdab:iecodebook export} ["/path/to/data"] {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
-{p 2 3}, [{bf:replace}] [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
+{p 2 4}, [{bf:replace}] [{opt text:only}] [{opt copy:data}] [{opt hash}] [{opt reset}] {break}
+    [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
 {hline}
 
@@ -140,10 +141,19 @@ For example, appending a same-named string variable to a numeric variable may ca
 {marker Options}{...}
 {synopthdr:Export Options}
 {synoptline}
-{synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook.{p_end}
+{synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook or dataset.{p_end}
 {break}
-{synopt:{opt trim()}} Takes one or more dofiles and trims the current dataset to only include variables used in those dofiles,
-and saves an identically named .dta file at the location specified in {it:"/path/to/codebook.xlsx"}.{p_end}
+{synopt:{opt text:only}}This option requests that the codebook be created as a plaintext file.{p_end}
+{break}
+{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook, with the same name.{p_end}
+{break}
+{synopt:{opt hash}}This option requests that a {help datasignature} be placed at the same location as the codebook,
+and will return an error if a datasignature file is already there and is different.{p_end}
+{break}
+{synopt:{opt reset}}This option allows {cmdab:iecodebook export} to overwrite an existing datasignature.{p_end}
+{break}
+{synopt:{opt trim()}}This option takes one or more dofiles as inputs, and trims the current dataset to only include variables used in those dofiles,
+before executing any of the other {bf: export} tasks requested.{p_end}
 {synoptline}
 
 {marker example}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -41,8 +41,9 @@ renames, recodes, variable labels, and value labels, and applies them to the cur
 {p 2 4}{cmdab:iecodebook append}{break} reads an Excel codebook that specifies how variables should be harmonized across
 two or more datasets - rename, recode, variable labels, and value labels - applies the harmonization, and appends the datasets.{p_end}
 {break}
-{p 2 4}{cmdab:iecodebook export}{break} creates an Excel codebook that describes the current dataset,
-and optionally produces an export version of the dataset with only variables used in specified dofiles.{p_end}
+{p 2 4}{cmdab:iecodebook export}{break} creates an Excel or plaintext codebook that describes the current dataset,
+optionally creates or verifies a datasignature for record-keeping, optionally re-saves the dataset in the specified location,
+and optionally reduces the dataset to only the variables used in a set of specified dofiles.{p_end}
 
 {title:Syntax}
 
@@ -78,7 +79,7 @@ and optionally produces an export version of the dataset with only variables use
 
 {p 2 4}{cmdab:iecodebook export} ["/path/to/data"] {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
-{p 2 4}, [{bf:replace}] [{opt text:only}] [{opt copy:data}] [{opt hash}] [{opt reset}] {break}
+{p 2 4}, [{bf:replace}] [{opt text:only}] [{opt copy:data}] [{opt sign:ature}] [{opt reset}] {break}
     [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
 {hline}
@@ -147,10 +148,13 @@ For example, appending a same-named string variable to a numeric variable may ca
 {break}
 {synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook, with the same name.{p_end}
 {break}
-{synopt:{opt hash}}This option requests that a {help datasignature} be placed at the same location as the codebook,
-and will return an error if a datasignature file is already there and is different.{p_end}
+{synopt:{opt sign:ature}}This option requests that a {help datasignature} be verified
+in the same destination folder as the codebook and/or data copy are placed,
+and will return an error if a datasignature file is not found or is different.{p_end}
 {break}
-{synopt:{opt reset}}This option allows {cmdab:iecodebook export} to overwrite an existing datasignature.{p_end}
+{synopt:{opt reset}}Specified with {opt sign:ature},
+this option allows {cmdab:iecodebook export} to place a new datasignature
+or overwrite an existing datasignature.{p_end}
 {break}
 {synopt:{opt trim()}}This option takes one or more dofiles as inputs, and trims the current dataset to only include variables used in those dofiles,
 before executing any of the other {bf: export} tasks requested.{p_end}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -79,7 +79,7 @@ and optionally reduces the dataset to only the variables used in a set of specif
 
 {p 2 4}{cmdab:iecodebook export} ["/path/to/data"] {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
-{p 2 4}, [{bf:replace}] [{opt text:only}] [{opt copy:data}] [{opt sign:ature}] [{opt reset}] {break}
+{p 2 4}, [{bf:replace}] [{bf:verify}] [{opt text:only}] [{opt copy:data}] [{opt sign:ature}] [{opt reset}] {break}
     [{bf:trim(}{it:"/path/to/dofile1.do"} [{it:"/path/to/dofile2.do"}] [...]{bf:)}]{p_end}
 
 {hline}
@@ -143,6 +143,9 @@ For example, appending a same-named string variable to a numeric variable may ca
 {synopthdr:Export Options}
 {synoptline}
 {synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook or dataset.{p_end}
+{break}
+{synopt:{opt verify}}This option orders {cmdab:iecodebook export} to confirm that the current data precisely matches an existing codebook.
+It will break with an error and describe all changes if there are any differences between the two.{p_end}
 {break}
 {synopt:{opt text:only}}This option requests that the codebook be created as a plaintext file.{p_end}
 {break}

--- a/src/help_files/iecodebook.sthlp
+++ b/src/help_files/iecodebook.sthlp
@@ -65,14 +65,15 @@ and optionally reduces the dataset to only the variables used in a set of specif
 {p 2 4}{cmdab:iecodebook template} {break}
 {it:"/path/to/survey1.dta" "/path/to/survey2.dta" [...]} {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break}{p_end}
-{p 2 4}, {bf:surveys(}{it:Survey1Name} {it:Survey2Name} [...]{bf:)} [{bf:match}] [{opth gen:erate(varname)}] [{bf:replace}]{p_end}
+{p 2 3}, {bf:surveys(}{it:Survey1Name} {it:Survey2Name} [...]{bf:)}
+{break} [{bf:match}] [{opth gen:erate(varname)}] [{bf:replace}]{p_end}
 
 {p 2 4}{cmdab:iecodebook append} {break}
 {it:"/path/to/survey1.dta" "/path/to/survey2.dta" [...]} {break}
 {help using} {it:"/path/to/codebook.xlsx"} {break} {p_end}
 {p 2 3}, {bf:clear} {bf:surveys(}{it:Survey1Name} {it:Survey2Name} [...]{bf:)} {break}
 [{opth gen:erate(varname)} {opt miss:ingvalues(# "label" [# "label" ...])}]{break}
-[{bf:report replace keepall}] {p_end}
+[{bf:report}] [{bf:replace}] [{bf:keepall}] {p_end}
 
 
 {dlgtab 0:Export: Creating codebooks and signatures for datasets}
@@ -145,17 +146,20 @@ For example, appending a same-named string variable to a numeric variable may ca
 {synoptline}
 {synopt:{opt replace}}This option allows {cmdab:iecodebook export} to overwrite an existing codebook or dataset.{p_end}
 {break}
-{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook, with the same name.{p_end}
+{synopt:{opt copy:data}}This option requests that a copy of the data be placed at the same location as the codebook,
+with the same name as the codebook.{p_end}
 {break}
 {synopt:{opt verify}}This option orders {cmdab:iecodebook export} to confirm that the current data precisely matches an existing codebook.
-It will break with an error and describe all changes if there are any differences between the two.{p_end}
+It will break with an error and describe all changes if there are any differences between the two.
+A new codebook will not be written in this case.{p_end}
 {break}
 {synopt:{opt text:only}}This option requests that the codebook be created as a plaintext file.
 This cannot be combined with {bf:verify}.{p_end}
 {break}
 {synopt:{opt sign:ature}}This option requests that a {help datasignature} be verified
 in the same destination folder as the codebook and/or data copy are placed,
-and will return an error if a datasignature file is not found or is different.{p_end}
+and will return an error if a datasignature file is not found or is different,
+guaranteeing data has not changed since the last {bf:reset} of the signature.{p_end}
 {break}
 {synopt:{opt reset}}Specified with {opt sign:ature},
 this option allows {cmdab:iecodebook export} to place a new datasignature


### PR DESCRIPTION
`iecodebook export` is now majorly upgraded as a data handling command. This PR includes the following new features:

- [x] The ability to `use` data by specifying a file path as a primary argument to the command.
- [x] ~`copy`~ `save`: An option to save ~a new copy of~ the dataset in the same location as the codebook is placed. (Intended for things like Box/Git workflows and other setups where data may have to be bounced between storage and functional location.)
- [x] `signature`: An option to write a datasignature and, later, to ensure that the data is _exactly_ the same as when it was last copied, otherwise throwing an error. (And its accompanying `replace` analogue, `reset`.)
- [x] `verify`: An option to verify the structure (not the contents) of dataset against a previously written codebook to ensure no changes have been made to the variables, their definitions, or, in the case of labelled variables, their value labels.
- [x] `textonly`: The ability to write a rudimentary plaintext codebook (for Git).
- [ ] And finally, `trim()`, which started it all, finally works in a reasonable way. Taking a list of do-files as its arguments, this option reads the contents of those do-files, and does its best to keep in the dataset _only_ those variables which are mentioned in the do-file, before passing the data through to any of the above. This is to facilitate the rapid creation of "release" datasets accompanying specific analytical tasks. (It doesn't work with every possible case, particularly macros and loops, but it's pretty good.)

- [ ] Additional error handling has been included to detect and report invalid variable labels and value labels (containing special characters) which have been a common source of failure for writing the codebook.

This issue supersedes all other `iecodebook` issues and is *important* when it can be reviewed as these tools are majorly needed (by me, at least).