### PR TITLE
iedup : error message for character `

### DIFF
--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -61,6 +61,15 @@
 				exit
 			}
 
+			* Test that the idvar does not contain the character `
+			cap assert !strpos(`idvar', "`")
+			if _rc {
+				noi di as error "{phang}The data set contains one or more observations that has the character `=char(96)' in the ID variable [`idvar']. This is the only character {inp:ieduplicates} cannot handle that is otherwise allowed in a variable in your version of Stata.{p_end}"
+				noi di ""
+				error 198
+				exit
+			}
+
 			** Making one macro with all variables that will be
 			*  imported and exported from the Excel file
 			local argumentVars `idvar' `uniquevars' `keepvars'
@@ -559,7 +568,7 @@
 				*Add list of variables that are different between the two duplicated id value in excel report in 'listofdiffs' variable
 				levelsof `idvar', local(list_dup_ids)
 				foreach id of local list_dup_ids {
-					
+
 					*reset list of differing vars between each loop
 					local difflist ""
 


### PR DESCRIPTION
`ieduplicates` now throws a helpful error if `` ` `` is used. Which is the only invalid value in the `idvar` after this fix and #172 

