### PR TITLE
Fix issue with drop option

### DIFF
--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -497,7 +497,7 @@ qui {
         
    			  cap confirm variable `theName'
           if _rc {
-            di as error "Error: variable [`theName'] on line `i' was not found"
+            di as error "Error: You requested changes to variable [`theName'] on line `I', but it was not found in the data."
             error 111
           }
 

--- a/src/ado_files/iecodebook.ado
+++ b/src/ado_files/iecodebook.ado
@@ -494,6 +494,13 @@ qui {
       if "`theName'"   != "" {
         // Drop if requested
         if ("`drop'" != "" & "`theRename'" == "") | ("`theRename'" == ".") {
+        
+   			  cap confirm variable `theName'
+          if _rc {
+            di as error "Error: variable [`theName'] on line `i' was not found"
+            error 111
+          }
+
           local allDrops "`allDrops' `theName'"
         }
         // Otherwise process requested changes as long as there is something specified


### PR DESCRIPTION
because the line that drops the variables is captured, when there was a problem with a variable, it simply did not drop any variables at all. @bbdaniels , can you please check this is in line with how the command deals with error messages? I believe this is my first edit to iecodebook